### PR TITLE
Add stop-daemon.sh script for graceful daemon termination

### DIFF
--- a/stop-daemon.sh
+++ b/stop-daemon.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo "Stopping Claude Auto Renew daemon..."
+
+# Kill all instances of the daemon script
+pkill -f "claude-auto-renew-daemon.sh"
+
+# Wait a moment for processes to terminate
+sleep 1
+
+# Check if any processes are still running
+remaining=$(ps aux | grep -i "claude-auto-renew-daemon" | grep -v grep | wc -l)
+
+if [ "$remaining" -eq 0 ]; then
+    echo "Daemon stopped successfully."
+else
+    echo "Warning: $remaining daemon process(es) still running."
+    echo "Trying force kill..."
+    pkill -9 -f "claude-auto-renew-daemon.sh"
+    sleep 1
+    
+    # Final check
+    remaining=$(ps aux | grep -i "claude-auto-renew-daemon" | grep -v grep | wc -l)
+    if [ "$remaining" -eq 0 ]; then
+        echo "Daemon force stopped successfully."
+    else
+        echo "Error: Unable to stop all daemon processes."
+    fi
+fi


### PR DESCRIPTION
- Created stop-daemon.sh script to cleanly stop claude-auto-renew-daemon.sh processes
- Includes force kill fallback if graceful termination fails
- Made executable and ready for use