### PR TITLE
Fix failing quick test for time format validation

### DIFF
--- a/test-quick.sh
+++ b/test-quick.sh
@@ -88,7 +88,7 @@ fi
 
 # Test 5: Test start time parsing
 print_test "Testing start time parameter parsing"
-if ./claude-daemon-manager.sh start --at "25:00" 2>&1 | grep -q "Invalid time format"; then
+if ./claude-daemon-manager.sh start --at "25:00" 2>&1 | grep -qE "Invalid (start |stop )?time format"; then
     print_pass "Invalid time format correctly rejected"
 else
     print_fail "Invalid time format not properly handled"


### PR DESCRIPTION
## Summary
• Fixed failing test case "Testing start time parameter parsing" 
• Updated test regex to accept specific error messages like "Invalid start time format" and "Invalid stop time format"
• Preserves helpful user experience with explicit error messages

## Problem
The quick test script expected error messages to contain exactly "Invalid time format" but the daemon manager outputs more specific messages like "Invalid start time format" and "Invalid stop time format" which provide better user experience.

## Solution
Instead of removing the helpful specific error messages, updated the test to use a flexible regex pattern that accepts:
- "Invalid start time format" 
- "Invalid stop time format"
- "Invalid time format"

This ensures tests pass while maintaining explicit error messages that help users understand exactly which parameter (start vs stop time) has an issue.

## Test plan
- [x] `./test-quick.sh` now passes all 14 tests
- [x] Start time validation still shows "Invalid start time format" 
- [x] Stop time validation still shows "Invalid stop time format"
- [x] Both error types are properly caught by the updated test

Fixes #7