### PR TITLE
Fix daemon crash caused by log pollution in calculate_sleep_duration()

### DIFF
--- a/claude-auto-renew-daemon.sh
+++ b/claude-auto-renew-daemon.sh
@@ -240,7 +240,8 @@ calculate_sleep_duration() {
     local minutes_remaining=$(get_minutes_until_reset)
     
     if [ -n "$minutes_remaining" ] && [ "$minutes_remaining" -gt 0 ]; then
-        log_message "Time remaining: $minutes_remaining minutes"
+        # Log to file directly, not stdout (avoid polluting function output)
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] Time remaining: $minutes_remaining minutes" >> "$LOG_FILE"
         
         if [ "$minutes_remaining" -le 5 ]; then
             # Check every 30 seconds when close to reset


### PR DESCRIPTION
# Fix Critical Daemon Crash Bug

## Summary
Fixes a critical bug that caused the auto-renewal daemon to crash immediately after startup, preventing it from monitoring Claude Code renewal windows.

## Problem
The daemon was exiting with a bash syntax error within seconds of starting:

```bash
./claude-auto-renew-daemon.sh: line 471: syntax error: operand expected 
(error token is "[2026-01-31 16:24:52] Time remaining: 215 minutes\n600")