### PR TITLE
Prevent daemon exit when logging remaining time

### DIFF
--- a/claude-auto-renew-daemon.sh
+++ b/claude-auto-renew-daemon.sh
@@ -240,7 +240,8 @@ calculate_sleep_duration() {
     local minutes_remaining=$(get_minutes_until_reset)
     
     if [ -n "$minutes_remaining" ] && [ "$minutes_remaining" -gt 0 ]; then
-        log_message "Time remaining: $minutes_remaining minutes"
+        # Avoid polluting command-substitution output used by sleep_duration.
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] Time remaining: $minutes_remaining minutes" >> "$LOG_FILE"
         
         if [ "$minutes_remaining" -le 5 ]; then
             # Check every 30 seconds when close to reset


### PR DESCRIPTION
## Summary
- keep the "Time remaining" message in the daemon log file
- stop that log line from being emitted on stdout inside `calculate_sleep_duration`
- preserve numeric stdout so `sleep_duration=$(calculate_sleep_duration)` stays valid

## Problem
`calculate_sleep_duration` is used in command substitution:

`sleep_duration=$(calculate_sleep_duration)`

Inside that function, `log_message` writes to stdout via `tee`. When `ccusage` returns a remaining-time value, the captured output can contain both:
- the log line
- the numeric sleep duration

That makes `sleep_duration` non-numeric, which can cause the daemon loop to fail when it reaches `sleep "$sleep_duration"`.

## Fix
Write the "Time remaining" message directly to the log file instead of sending it through `log_message`, so the function still logs the state but only emits the numeric duration on stdout.

## Validation
- reproduced the daemon exiting after startup when a remaining-time value was returned
- verified the patched daemon continues to log `Next check in ... minutes`
- verified the daemon remains running after the first monitoring cycle
